### PR TITLE
Ignore embeds in edit logging

### DIFF
--- a/bot/clem_bot.py
+++ b/bot/clem_bot.py
@@ -75,7 +75,7 @@ class ClemBot(commands.Bot):
         await messenger.publish(Events.on_guild_role_delete, role)
 
     async def on_message_edit(self, before, after):
-        if before.author.id != self.user.id:
+        if before.author.id != self.user.id and len(before.embeds) == 0:
             await messenger.publish(Events.on_message_edit, before, after)
     
     async def on_message_delete(self, message):


### PR DESCRIPTION
Right now if a seperate bot edits an embed Clembots logging bugs out. This will stop that