### PR TITLE
Added lowercase conversion when using "tag info"

### DIFF
--- a/bot/cogs/tags_cog.py
+++ b/bot/cogs/tags_cog.py
@@ -116,7 +116,9 @@ class TagCog(commands.Cog):
 
     @tag.command(aliases=['info'])
     async def about(self, ctx, name):
-
+        
+        name = name.lower()
+        
         repo = TagRepository()
 
         if not await repo.check_tag_exists(name, ctx.guild.id):


### PR DESCRIPTION
When using `tag add` the tag name is converted to lowercase before creating it, but when using `tag info` the name is not converted to lowercase before searching.
Adding the conversion fixed it. #193