### PR TITLE
Fixed clearing all reactions on deletable timeout (issue #194)

### DIFF
--- a/bot/services/delete_message_service.py
+++ b/bot/services/delete_message_service.py
@@ -47,7 +47,7 @@ class DeleteMessageService(BaseService):
         if timeout:
             await asyncio.sleep(timeout) 
             try:
-                await msg[-1].clear_reactions()
+                await msg[-1].clear_reaction("🗑️")
                 del self.messages[msg[-1].id]
             except:
                 pass


### PR DESCRIPTION
Changed a line to remove just the wastebasket emote when the deletable listener times out, instead of clearing all reactions. 