### PR TITLE
Added id callbacks for the designated channel service

### DIFF
--- a/bot/messaging/events.py
+++ b/bot/messaging/events.py
@@ -236,8 +236,22 @@ class EventsMeta(type):
             channel_type (str) The designated channel to send the message in
             guild_id (int) The id of the guild to attempt to send a message in
             message (union[embed, str]) the message to be sent to the channel
+            id [Optional] (int) Id to associate a sent dc message with sent message ids at the publish site
         """
         return 'on_send_in_designated_channel'
+
+    @property
+    def on_designated_message_sent(self):
+        """
+        Published when an on_send_in_designate_channel event is published with an optional id parameter, 
+        this serves as a callback for that event to maintain seperation of concerns
+
+        Args:
+
+            dc_id (int) The id of the dc send event that was given to the dc service
+            message_id (Union[int, list[int]]) the id or the list of The ids of the sent messages in dc channels
+        """
+        return 'on_designated_message_sent'
 
     @property
     def on_broadcast_designated_channel(self):

--- a/bot/services/base_service.py
+++ b/bot/services/base_service.py
@@ -11,6 +11,7 @@ class BaseService(abc.ABC):
 
     def __init__(self, bot):
         self.bot = bot
+        self.messenger = bot.messenger
 
         for _, value in inspect.getmembers(self):
             event = None

--- a/bot/services/designated_channel_service.py
+++ b/bot/services/designated_channel_service.py
@@ -19,14 +19,17 @@ class DesignatedChannelService(BaseService):
     async def send_designated_message(self, 
             designated_name: DesignatedChannels, 
             guild_id: int, 
-            content: Union[str, discord.Embed]):
+            content: Union[str, discord.Embed],
+            dc_id: int=None):
         """
         Event call back to sent a given string or embed message to all registered designated channels
         in a given guild
 
         Args:
             designated_name (DesignatedChannels): The enum name of the designated channel
+            guild_id (int): the guild to send the message in
             content (Union[str, discord.Embed]): The message to send
+            dc_id [optional] (int) an optional callback id to associate sent dc messages at the publish site
         """
         dc_repo = DesignatedChannelRepository()
         assigned_channel_ids = await dc_repo.get_guild_designated_channels(designated_name.name, guild_id)
@@ -34,7 +37,10 @@ class DesignatedChannelService(BaseService):
         if assigned_channel_ids is None:
             return
         
-        await self._send_dc_messages(assigned_channel_ids, content)
+        sent_ids = await self._send_dc_messages(assigned_channel_ids, content)
+
+        if dc_id:
+            await self.messenger.publish(Events.on_designated_message_sent, dc_id, sent_ids)
 
     @BaseService.Listener(Events.on_broadcast_designated_channel)
     async def broadcast_designated_message(self, 
@@ -62,13 +68,18 @@ class DesignatedChannelService(BaseService):
         if await repo.check_channel(channel):
             await repo.remove_from_all_designated_channels(channel)
         
-    async def _send_dc_messages(self, assigned_channel_ids: List[int], content: Union[str, discord.Embed]):
+    async def _send_dc_messages(self, assigned_channel_ids: List[int], content: Union[str, discord.Embed]) -> List[int]:
+        sent_ids = []
+
         if len(assigned_channel_ids) > 0:
             for channel_id in assigned_channel_ids:
                 if isinstance(content, str):
-                    await self.bot.get_channel(channel_id).send(content)
+                    mes = await self.bot.get_channel(channel_id).send(content)
+                    sent_ids.append(mes.id)
                 elif isinstance(content, discord.Embed):
-                    await self.bot.get_channel(channel_id).send(embed= content)
+                    mes = await self.bot.get_channel(channel_id).send(embed= content)
+                    sent_ids.append(mes.id)
+        return sent_ids
 
     async def load_service(self):
         repo = DesignatedChannelRepository()


### PR DESCRIPTION
When i designed the messenger system for Clembot i designed it to be fire and forget, publishers were not supposed to know or care about the result of the message, this works well for most things, it allows us to totally decentralize our codebase and create a project made up of non coupled "modules", however the fire and forget pattern is not always desirable. We sometimes to want to know the result of an event, in this case, to maintain our decentralized event pattern and prevent over-reliance on the messenger we must decouple the event publish from the event result. We can do this by having callback ids that the destination of the event will rebroadcast on successful completion of that event, this allows us to be both decoupled and also more modular because we are now notifying the entire code base of the success of an operation that they can optionally subscribe too. 

cc: @new-zelind this is per our star board discussion so this should be what you need to go ahead with that feature