### PR TITLE
Made clembots mention a global command prefix

### DIFF
--- a/bot/custom_prefix.py
+++ b/bot/custom_prefix.py
@@ -1,7 +1,10 @@
 import typing as t
 import logging
+from functools import reduce 
+import operator
 
 import discord
+from discord.ext import commands
 
 log = logging.getLogger(__name__)
 
@@ -14,11 +17,13 @@ class CustomPrefix:
         self.default = default
     
     def get_prefix(self, bot, message):
-        if message.guild.id not in self.prefixes.keys():
-            return self.default
+        if message.guild.id not in self.prefixes:
+            prefixes = self.default
         else:
-            return self.prefixes[message.guild.id]
+            prefixes = self.prefixes[message.guild.id] 
 
-    async def set_prefix(self, guild: discord.Guild, prefix: str):
+        return commands.when_mentioned_or(*prefixes)(bot, message)
+        
+    async def set_prefix(self, guild: discord.Guild, prefix: t.Tuple[str]):
         log.info(f'Setting custom prefix in guild: {guild.name}({guild.id}) to "{prefix}""')
         self.prefixes[guild.id] = prefix

--- a/bot/services/message_handling_service.py
+++ b/bot/services/message_handling_service.py
@@ -22,9 +22,6 @@ class MessageHandlingService(BaseService):
     async def on_message_recieved(self, message: discord.Message) -> None:
         log.info(f'Message from {message.author}: "{message.content}" Guild {message.guild.id}')
 
-        if self.bot.user.mentioned_in(message) and message.mention_everyone is False:
-            await message.channel.send('Hello there everyone!!')
-
         await self.handle_message_links(message)
 
         #Primary entry point for handling commands


### PR DESCRIPTION
You can now invoke clembot commands with the bots mention `@ClemBot Hello` no matter what the custom prefix is set too. This allows you to always reset the prefix no matter what.

closes #214 