### PR TITLE
Define Cog Fix

### DIFF
--- a/bot/cogs/define_cog.py
+++ b/bot/cogs/define_cog.py
@@ -19,7 +19,6 @@ class defineCog(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        self.api_key = BotSecrets.get_instance().merriam_key
     
     def getPageData(self, jsonData, word):
         pages = []
@@ -100,6 +99,8 @@ class defineCog(commands.Cog):
         For phrases, use underscores
         EXAMPLE: define computer_science
         """
+
+        self.api_key = BotSecrets.get_instance().merriam_key
 
         actualWord = word.replace('_',' ')
         word = word.replace('_','%20').lower()


### PR DESCRIPTION
Per #233, fixed an issue where the `define` cog would prevent bot initialization if the `MerriamKey` entry was empty in `BotSecrets.json`.