### PR TITLE
Added use counter to tags (Issue #200)

### DIFF
--- a/bot/cogs/tags_cog.py
+++ b/bot/cogs/tags_cog.py
@@ -28,7 +28,6 @@ class Tag:
     creation_date: str
     guild_id: int
     user_id: int
-    #use_count: int
 
 
 class TagCog(commands.Cog):
@@ -157,7 +156,6 @@ class TagCog(commands.Cog):
 
         author = self.bot.get_user(tag['fk_UserId'])
         
-
         embed = discord.Embed(title='Tag Information:', color=Colors.ClemsonOrange)
         embed.add_field(name='Name ', value=tag['name'])
         embed.add_field(name='Uses ', value=tag['useCount'])

--- a/bot/cogs/tags_cog.py
+++ b/bot/cogs/tags_cog.py
@@ -28,6 +28,7 @@ class Tag:
     creation_date: str
     guild_id: int
     user_id: int
+    #use_count: int
 
 
 class TagCog(commands.Cog):
@@ -106,7 +107,7 @@ class TagCog(commands.Cog):
             embed = discord.Embed(title= f'Error: Tag "{name}" already exists in this server', color=Colors.Error)
             await ctx.send(embed=embed)
             return
-            
+  
         tag = Tag(name, content, datetime.utcnow(), ctx.guild.id, ctx.author.id)
         await TagRepository().insert_tag(tag)
 
@@ -155,9 +156,11 @@ class TagCog(commands.Cog):
         tag = await repo.get_tag(name, ctx.guild.id)
 
         author = self.bot.get_user(tag['fk_UserId'])
+        
 
         embed = discord.Embed(title='Tag Information:', color=Colors.ClemsonOrange)
         embed.add_field(name='Name ', value=tag['name'])
+        embed.add_field(name='Uses ', value=tag['useCount'])
         embed.add_field(name='Content ', value=tag['content'])
         fullNameGet = self.get_full_name(author)
         embed.set_footer(text=fullNameGet, icon_url=author.avatar_url)

--- a/bot/data/CreateTables.sql
+++ b/bot/data/CreateTables.sql
@@ -92,6 +92,7 @@ CREATE TABLE IF NOT EXISTS Tags (
     id                      INTEGER     PRIMARY KEY,
     name                    TEXT        NOT NULL,
     content                 TEXT        NOT NULL,
+    useCount                INTEGER     DEFAULT 0,
     CreationDate            TEXT        NOT NULL,
     fk_GuildId              INTEGER     NOT NULL,
     fk_UserId               INTEGER     NOT NULL,

--- a/bot/data/tag_repository.py
+++ b/bot/data/tag_repository.py
@@ -29,10 +29,13 @@ class TagRepository(BaseRepository):
                 (name, guild_id)) as c:
                 return await c.fetchone() is not None
 
-    async def get_tag_content(self, name: str, guild_id: int) -> str:
+    async def increment_tag_use_counter(self, name: str, guild_id: int) -> str:
         async with aiosqlite.connect(self.resolved_db_path) as db:
             await db.execute('UPDATE Tags SET useCount = useCount + 1 WHERE name = ? AND fk_guildId = ?', (name, guild_id,))
             await db.commit()
+
+    async def get_tag_content(self, name: str, guild_id: int) -> str:
+        async with aiosqlite.connect(self.resolved_db_path) as db:
             async with db.execute('SELECT Content FROM Tags WHERE name = ? AND fk_guildId = ?',
                     (name, guild_id,)) as c:
                 return (await self.fetcthone_as_dict(c))['content']

--- a/bot/data/tag_repository.py
+++ b/bot/data/tag_repository.py
@@ -31,6 +31,8 @@ class TagRepository(BaseRepository):
 
     async def get_tag_content(self, name: str, guild_id: int) -> str:
         async with aiosqlite.connect(self.resolved_db_path) as db:
+            await db.execute('UPDATE Tags SET useCount = useCount + 1 WHERE name = ? AND fk_guildId = ?', (name, guild_id,))
+            await db.commit()
             async with db.execute('SELECT Content FROM Tags WHERE name = ? AND fk_guildId = ?',
                     (name, guild_id,)) as c:
                 return (await self.fetcthone_as_dict(c))['content']

--- a/bot/services/tag_service.py
+++ b/bot/services/tag_service.py
@@ -32,6 +32,7 @@ class TagService(BaseService):
             return
 
         content = await repo.get_tag_content(name, message.guild.id)
+        await repo.increment_tag_use_counter(name, message.guild.id)
         log.info(f'Tag "{found_name}" invoked in guild: {message.guild.id} by: {message.author.id}')
         msg = await message.channel.send(content)
         await self.bot.messenger.publish(Events.on_set_deletable, 


### PR DESCRIPTION
Adds a useCounter column to the Tags database, and increments the counter for each tag when called. Can see the number of calls by using the !tags info command on a specific tag. 

@Jay-Madden if you make the script to bring the production DB up to speed, the default 0 flag on the useCount should make older tags work I think. 