### PR TITLE
Fix translate_cog.py

### DIFF
--- a/bot/cogs/translate_cog.py
+++ b/bot/cogs/translate_cog.py
@@ -74,6 +74,8 @@ LANGUAGE_SHORT_CODE_TO_NAME = {value : key for key, value in LANGUAGE_NAME_TO_SH
 
 TRANSLATE_API_URL = "https://api.cognitive.microsofttranslator.com/translate"
 
+TRACE_ID = str(uuid.uuid4())
+
 class TranslateCog(commands.Cog):
 
     def __init__(self, bot):
@@ -130,7 +132,7 @@ class TranslateCog(commands.Cog):
                         'Ocp-Apim-Subscription-Key': BotSecrets.get_instance().azure_translate_key,
                         'Ocp-Apim-Subscription-Region': 'global',
                         'Content-type': 'application/json',
-                        'X-ClientTraceId': str(uuid.uuid4())
+                        'X-ClientTraceId': TRACE_ID
                     }
 
         async with aiohttp.ClientSession() as session:
@@ -166,7 +168,7 @@ class TranslateCog(commands.Cog):
                         'Ocp-Apim-Subscription-Key': BotSecrets.get_instance().azure_translate_key,
                         'Ocp-Apim-Subscription-Region': 'global',
                         'Content-type': 'application/json',
-                        'X-ClientTraceId': str(uuid.uuid4())
+                        'X-ClientTraceId': TRACE_ID
                     }
 
         async with aiohttp.ClientSession() as session:

--- a/bot/cogs/translate_cog.py
+++ b/bot/cogs/translate_cog.py
@@ -72,14 +72,6 @@ LANGUAGE_NAME_TO_SHORT_CODE = {
 CHUNK_SIZE = 15
 LANGUAGE_SHORT_CODE_TO_NAME = {value : key for key, value in LANGUAGE_NAME_TO_SHORT_CODE.items()}
 
-HEADERS = {
-    'Ocp-Apim-Subscription-Key': BotSecrets.get_instance().azure_translate_key,
-    'Ocp-Apim-Subscription-Region': 'global',
-    'Content-type': 'application/json',
-    'X-ClientTraceId': str(uuid.uuid4())
-}
-
-
 TRANSLATE_API_URL = "https://api.cognitive.microsofttranslator.com/translate"
 
 class TranslateCog(commands.Cog):
@@ -134,8 +126,15 @@ class TranslateCog(commands.Cog):
             'text': text
         }]
 
+        headers = {
+                        'Ocp-Apim-Subscription-Key': BotSecrets.get_instance().azure_translate_key,
+                        'Ocp-Apim-Subscription-Region': 'global',
+                        'Content-type': 'application/json',
+                        'X-ClientTraceId': str(uuid.uuid4())
+                    }
+
         async with aiohttp.ClientSession() as session:
-            async with await session.post(url = TRANSLATE_API_URL, params = params, headers = HEADERS, json = body) as resp: 
+            async with await session.post(url = TRANSLATE_API_URL, params = params, headers = headers, json = body) as resp: 
                 response = json.loads(await resp.text())
 
         log.info(response[0]['translations'])
@@ -163,8 +162,15 @@ class TranslateCog(commands.Cog):
             'text': text
         }]
         
+        headers = {
+                        'Ocp-Apim-Subscription-Key': BotSecrets.get_instance().azure_translate_key,
+                        'Ocp-Apim-Subscription-Region': 'global',
+                        'Content-type': 'application/json',
+                        'X-ClientTraceId': str(uuid.uuid4())
+                    }
+
         async with aiohttp.ClientSession() as session:
-            async with await session.post(url = TRANSLATE_API_URL, params = params, headers = HEADERS, json = body) as resp: 
+            async with await session.post(url = TRANSLATE_API_URL, params = params, headers = headers, json = body) as resp: 
                 response = json.loads(await resp.text())
         
         log.info(response[0]['detectedLanguage'])


### PR DESCRIPTION
Fixes an issue with the translate cog where the bot wouldn't start if it didn't have an Azure translate key in BotSecrets.json.