### PR TITLE
Fixed BotSecrets Template

### DIFF
--- a/BotSecrets.json.template
+++ b/BotSecrets.json.template
@@ -7,9 +7,9 @@
     "GifMeToken": "",
     "ReplUrl": "",
     "GithubSourceUrl": "",
-    "MerriamKey": ""
+    "MerriamKey": "",
     "WeatherKey": "",
-    "GeocodeKey": ""
+    "GeocodeKey": "",
     "MerriamKey": "",
     "AzureTranslateKey": ""
 }

--- a/BotSecrets.json.template
+++ b/BotSecrets.json.template
@@ -7,7 +7,6 @@
     "GifMeToken": "",
     "ReplUrl": "",
     "GithubSourceUrl": "",
-    "MerriamKey": "",
     "WeatherKey": "",
     "GeocodeKey": "",
     "MerriamKey": "",


### PR DESCRIPTION
Two key value lines were missing commas.
Caused issues when setting up a new test instance