### PR TITLE
Fixed NoneType Error from Bot DMs

### DIFF
--- a/bot/clem_bot.py
+++ b/bot/clem_bot.py
@@ -116,7 +116,10 @@ class ClemBot(commands.Bot):
             message ([type]): The d.py message object
         """
         if message.author.id != self.user.id:
-            await self.publish_with_error(Events.on_message_received, message)
+            if not isinstance(message.guild, discord.guild.Guild):
+                await self.publish_with_error(Events.on_dm_message_received, message)
+            else:
+                await self.publish_with_error(Events.on_guild_message_received, message)
 
     async def on_guild_join(self, guild):
         await self.publish_with_error(Events.on_guild_joined, guild)

--- a/bot/clem_bot.py
+++ b/bot/clem_bot.py
@@ -116,7 +116,7 @@ class ClemBot(commands.Bot):
             message ([type]): The d.py message object
         """
         if message.author.id != self.user.id:
-            await self.publish_with_error(Events.on_message_recieved, message)
+            await self.publish_with_error(Events.on_message_received, message)
 
     async def on_guild_join(self, guild):
         await self.publish_with_error(Events.on_guild_joined, guild)

--- a/bot/consts.py
+++ b/bot/consts.py
@@ -27,6 +27,7 @@ class OwnerDesignatedChannels(DesignatedChannelBase):
 
     server_join_log = auto()
     error_log = auto()
+    bot_dm_log = auto()
 
     @staticmethod
     def has(member: str) -> bool:

--- a/bot/messaging/events.py
+++ b/bot/messaging/events.py
@@ -19,14 +19,14 @@ class EventsMeta(type):
         return 'on_example'
 
     @property
-    def on_message_recieved(self):
+    def on_message_received(self):
         """
         Published whenever a message is sent in a server
         
         Args:
             message (Message) – The deleted message.
         """
-        return '_on_message_recieved'
+        return '_on_message_received'
 
     @property
     def on_raw_message_edit(self):
@@ -265,7 +265,7 @@ class EventsMeta(type):
     @property
     def on_broadcast_designated_channel(self):
         """
-        Published when a reqeust to broadcast a message to all registered channels
+        Published when a request to broadcast a message to all registered channels
         in all servers is sent
 
         Args:

--- a/bot/messaging/events.py
+++ b/bot/messaging/events.py
@@ -19,14 +19,24 @@ class EventsMeta(type):
         return 'on_example'
 
     @property
-    def on_message_received(self):
+    def on_guild_message_received(self):
         """
         Published whenever a message is sent in a server
         
         Args:
             message (Message) – The deleted message.
         """
-        return '_on_message_received'
+        return '_on_guild_message_received'
+
+    @property
+    def on_dm_message_received(self):
+        """
+        Published whenever a direct message is sent to ClemBot
+        
+        Args:
+            message (Message) – The deleted message.
+        """
+        return '_on_dm_message_received'
 
     @property
     def on_raw_message_edit(self):

--- a/bot/services/example_service.py
+++ b/bot/services/example_service.py
@@ -34,7 +34,7 @@ class ExampleService(BaseService):
     #This is the decorator for the messenger that marks a given message as a callback for an event,
     #if an event is not supplied it will default to the name of the method as the event
     @BaseService.Listener(Events.on_example)
-    async def on_message_recieved(self, message) -> None:
+    async def on_guild_message_received(self, message) -> None:
         pass
     
     #The load service abstract method implementation defined in BaseService

--- a/bot/services/message_handling_service.py
+++ b/bot/services/message_handling_service.py
@@ -21,10 +21,7 @@ class MessageHandlingService(BaseService):
     @BaseService.Listener(Events.on_message_received)
     async def on_message_received(self, message: discord.Message) -> None:
         
-        if isinstance(message.guild, discord.guild.Guild):
-            log.info(f'Message from {message.author}: "{message.content}" Guild {message.guild.id}')
-            log.info(f'{type(message.guild)}')
-        else:
+        if not isinstance(message.guild, discord.guild.Guild):
             embed = discord.Embed(title= f'Bot Direct Message',
                                     color= Colors.ClemsonOrange,
                                     description= f'{message.content}')
@@ -34,7 +31,8 @@ class MessageHandlingService(BaseService):
             await self.messenger.publish(Events.on_broadcast_designated_channel, OwnerDesignatedChannels.bot_dm_log, embed)
             #await message.author.send('👋') # https://discordpy.readthedocs.io/en/latest/faq.html#how-do-i-send-a-dm
             return
-
+        log.info(f'Message from {message.author}: "{message.content}" Guild {message.guild.id}')
+        log.info(f'{type(message.guild)}')
 
         await self.handle_message_links(message)
 

--- a/bot/services/message_handling_service.py
+++ b/bot/services/message_handling_service.py
@@ -18,28 +18,25 @@ class MessageHandlingService(BaseService):
     def __init__(self, *, bot):
         super().__init__(bot)
 
-    @BaseService.Listener(Events.on_message_received)
-    async def on_message_received(self, message: discord.Message) -> None:
-        
-        if not isinstance(message.guild, discord.guild.Guild):
-            embed = discord.Embed(title= f'Bot Direct Message',
-                                    color= Colors.ClemsonOrange,
-                                    description= f'{message.content}')
-            embed.set_footer(text=message.author, icon_url=message.author.avatar_url)
-            log.info(f'Message from {message.author}: "{message.content}" Guild Unknown (DM)')
-            log.info(f'{message.guild}')
-            await self.messenger.publish(Events.on_broadcast_designated_channel, OwnerDesignatedChannels.bot_dm_log, embed)
-            #await message.author.send('👋') # https://discordpy.readthedocs.io/en/latest/faq.html#how-do-i-send-a-dm
-            return
+    @BaseService.Listener(Events.on_guild_message_received)
+    async def on_guild_message_received(self, message: discord.Message) -> None:
         log.info(f'Message from {message.author}: "{message.content}" Guild {message.guild.id}')
-        log.info(f'{type(message.guild)}')
-
         await self.handle_message_links(message)
 
         #Primary entry point for handling commands
         await self.bot.process_commands(message)
 
         await MessageRepository().add_message(message, datetime.datetime.utcnow())
+
+    @BaseService.Listener(Events.on_dm_message_received)
+    async def on_dm_message_received(self, message: discord.Message) -> None:
+        embed = discord.Embed(title= f'Bot Direct Message',
+                                color= Colors.ClemsonOrange,
+                                description= f'{message.content}')
+        embed.set_footer(text=message.author, icon_url=message.author.avatar_url)
+        log.info(f'Message from {message.author}: "{message.content}" Guild Unknown (DM)')
+        await self.messenger.publish(Events.on_broadcast_designated_channel, OwnerDesignatedChannels.bot_dm_log, embed)
+        #await message.author.send('👋') # https://discordpy.readthedocs.io/en/latest/faq.html#how-do-i-send-a-dm
 
     @BaseService.Listener(Events.on_message_edit)
     async def on_message_edit(self, before: discord.Message, after: discord.Message):

--- a/bot/services/message_handling_service.py
+++ b/bot/services/message_handling_service.py
@@ -21,13 +21,16 @@ class MessageHandlingService(BaseService):
     @BaseService.Listener(Events.on_message_received)
     async def on_message_received(self, message: discord.Message) -> None:
         
-        try:
+        if isinstance(message.guild, discord.guild.Guild):
             log.info(f'Message from {message.author}: "{message.content}" Guild {message.guild.id}')
-        except AttributeError as err:
-            embed = discord.Embed(title= f'Bot DM from {message.author}',
+            log.info(f'{type(message.guild)}')
+        else:
+            embed = discord.Embed(title= f'Bot Direct Message',
                                     color= Colors.ClemsonOrange,
-                                    description= f'"{message.content}"')
+                                    description= f'{message.content}')
+            embed.set_footer(text=message.author, icon_url=message.author.avatar_url)
             log.info(f'Message from {message.author}: "{message.content}" Guild Unknown (DM)')
+            log.info(f'{message.guild}')
             await self.messenger.publish(Events.on_broadcast_designated_channel, OwnerDesignatedChannels.bot_dm_log, embed)
             #await message.author.send('👋') # https://discordpy.readthedocs.io/en/latest/faq.html#how-do-i-send-a-dm
             return

--- a/bot/services/message_handling_service.py
+++ b/bot/services/message_handling_service.py
@@ -6,7 +6,7 @@ import json
 
 import discord
 
-from bot.consts import Colors, DesignatedChannels
+from bot.consts import Colors, DesignatedChannels, OwnerDesignatedChannels
 from bot.data.message_repository import MessageRepository
 from bot.messaging.events import Events
 from bot.services.base_service import BaseService
@@ -18,9 +18,20 @@ class MessageHandlingService(BaseService):
     def __init__(self, *, bot):
         super().__init__(bot)
 
-    @BaseService.Listener(Events.on_message_recieved)
-    async def on_message_recieved(self, message: discord.Message) -> None:
-        log.info(f'Message from {message.author}: "{message.content}" Guild {message.guild.id}')
+    @BaseService.Listener(Events.on_message_received)
+    async def on_message_received(self, message: discord.Message) -> None:
+        
+        try:
+            log.info(f'Message from {message.author}: "{message.content}" Guild {message.guild.id}')
+        except AttributeError as err:
+            embed = discord.Embed(title= f'Bot DM from {message.author}',
+                                    color= Colors.ClemsonOrange,
+                                    description= f'"{message.content}"')
+            log.info(f'Message from {message.author}: "{message.content}" Guild Unknown (DM)')
+            await self.messenger.publish(Events.on_broadcast_designated_channel, OwnerDesignatedChannels.bot_dm_log, embed)
+            #await message.author.send('👋') # https://discordpy.readthedocs.io/en/latest/faq.html#how-do-i-send-a-dm
+            return
+
 
         await self.handle_message_links(message)
 

--- a/bot/services/tag_service.py
+++ b/bot/services/tag_service.py
@@ -21,6 +21,9 @@ class TagService(BaseService):
     
     @BaseService.Listener(Events.on_message_received)
     async def on_message_received(self, message: discord.Message) -> None:
+        if not isinstance(message.guild, discord.guild.Guild):
+            return
+        
         repo = TagRepository()
 
         tagsContent = []

--- a/bot/services/tag_service.py
+++ b/bot/services/tag_service.py
@@ -19,8 +19,8 @@ class TagService(BaseService):
     def __init__(self, *, bot):
         super().__init__(bot)
     
-    @BaseService.Listener(Events.on_message_recieved)
-    async def on_message_recieved(self, message: discord.Message) -> None:
+    @BaseService.Listener(Events.on_message_received)
+    async def on_message_received(self, message: discord.Message) -> None:
         repo = TagRepository()
 
         tagsContent = []

--- a/bot/services/tag_service.py
+++ b/bot/services/tag_service.py
@@ -19,8 +19,8 @@ class TagService(BaseService):
     def __init__(self, *, bot):
         super().__init__(bot)
     
-    @BaseService.Listener(Events.on_message_received)
-    async def on_message_received(self, message: discord.Message) -> None:
+    @BaseService.Listener(Events.on_guild_message_received)
+    async def on_guild_message_received(self, message: discord.Message) -> None:
         if not isinstance(message.guild, discord.guild.Guild):
             return
         

--- a/bot/services/tag_service.py
+++ b/bot/services/tag_service.py
@@ -21,9 +21,6 @@ class TagService(BaseService):
     
     @BaseService.Listener(Events.on_guild_message_received)
     async def on_guild_message_received(self, message: discord.Message) -> None:
-        if not isinstance(message.guild, discord.guild.Guild):
-            return
-        
         repo = TagRepository()
 
         tagsContent = []


### PR DESCRIPTION
Resolves NoneType error caused by the bot receiving a DM.

Logs all messages to owner-designated `bot_dm_log` channel.