### PR TITLE
Added more to the info cog

### DIFF
--- a/bot/cogs/info_cog.py
+++ b/bot/cogs/info_cog.py
@@ -33,8 +33,8 @@ class InfoCog(commands.Cog):
 
         user_info = f'» **Nickname:** {user.mention}'
         user_info += f'\n» **ID:** {user.id}'
-        #Some info doesn't need to be available to anyone to check
-        if await self.bot.claims_check(ctx=ctx):
+        #Some info doesn't need to be available to anyone to check on for other users
+        if (await self.bot.claims_check(ctx=ctx)) or (ctx.author.id == user.id):
             #prints the datetime in the format of <Months> <day> <year> <hours>:<minutes>:<seconds> <AM/PM>
             user_info += '\n» **Created:** ' + user.created_at.strftime('%b %d %Y %I:%M:%S %p')
         embed.add_field(name='**User ID:**', value=user_info)
@@ -53,7 +53,7 @@ class InfoCog(commands.Cog):
         #check to see if the target user is in the calling context's guild. If None then the user isn't in the calling server
         if member:
             guild_info = ''
-            if await self.bot.claims_check(ctx=ctx) is True:
+            if (await self.bot.claims_check(ctx=ctx)) or (ctx.author.id == user.id):
                 #prints the datetime in the format of <Months> <day> <year> <hours>:<minutes>:<seconds> <AM/PM>
                 guild_info = '» **Joined:** ' + member.joined_at.strftime('%b %d %Y %I:%M:%S %p') 
             guild_info += f'\n» **Message count (last 30 days):** {await MessageRepository().get_user_message_count_range(member.id, ctx.guild.id, 30)}'

--- a/bot/cogs/info_cog.py
+++ b/bot/cogs/info_cog.py
@@ -21,44 +21,45 @@ class InfoCog(commands.Cog):
     @ext.example(('info @user', 'info 123456789', 'info'))
     @ext.required_claims(Claims.moderation_infraction_view)
     @ext.ignore_claims_pre_invoke()
-    async def info(self, ctx, member: discord.Member = None):
-        #If the command is invoked without a specified member, it will return info on the calling user
-        if not member:
-            member = ctx.author
-        log.info(f'User {ctx.author} has ran info command on user {member.name}')
+    async def info(self, ctx, user: discord.User = None):
+        #If the command is invoked without a specified user, it will return info on the calling user
+        if not user:
+            user = ctx.author
+        log.info(f'User {ctx.author} has ran info command on user {user.name}')
 
         embed = discord.Embed(title = f'Guild Member Information', color=Colors.ClemsonOrange)
-        embed.set_author(name=f'{member.name}#{member.discriminator}', icon_url=member.avatar_url)
+        embed.set_author(name=f'{user.name}#{user.discriminator}', icon_url=user.avatar_url)
 
-        user_info = f'» **Nickname:** {member.mention}'
-        user_info += f'\n» **ID:** {member.id}'
+        user_info = f'» **Nickname:** {user.mention}'
+        user_info += f'\n» **ID:** {user.id}'
         #Some info doesn't need to be available to anyone to check
         if await self.bot.claims_check(ctx=ctx):
             #prints the datetime in the format of <Months> <day> <year> <hours>:<minutes>:<seconds> <AM/PM>
-            user_info += '\n» **Created:** ' + member.created_at.strftime('%b %d %Y %I:%M:%S %p')
-        embed.add_field(name='**Member ID:**', value=user_info)
-        embed.set_thumbnail(url=member.avatar_url)
-
+            user_info += '\n» **Created:** ' + user.created_at.strftime('%b %d %Y %I:%M:%S %p')
+        embed.add_field(name='**User ID:**', value=user_info)
+        embed.set_thumbnail(url=user.avatar_url)
+            
         #We don't want moderation info available for regular guild users to check on others
         if await self.bot.claims_check(ctx=ctx) is True:
-            moderation_info = f'» **Warnings:** {len(await ModerationRepository().get_all_warns_member(member.guild.id, member.id))}'
-            moderation_info += f'\n» **Active Mutes:** {len(await ModerationRepository().get_all_active_mutes_member(member.guild.id, member.id))}'
-            moderation_info += f'\n» **Total Infractions:** {len(await ModerationRepository().get_all_infractions_member(member.guild.id, member.id))}'
+            moderation_info = f'» **Warnings:** {len(await ModerationRepository().get_all_warns_member(ctx.guild.id, user.id))}'
+            moderation_info += f'\n» **Active Mutes:** {len(await ModerationRepository().get_all_active_mutes_member(ctx.guild.id, user.id))}'
+            moderation_info += f'\n» **Total Infractions:** {len(await ModerationRepository().get_all_infractions_member(ctx.guild.id, user.id))}'
             embed.add_field(name='**Moderation Info:**', value=moderation_info)
 
-        guild_info = ''
-        if await self.bot.claims_check(ctx=ctx) is True:
-            #prints the datetime in the format of <Months> <day> <year> <hours>:<minutes>:<seconds> <AM/PM>
-            guild_info = '» **Joined:** ' + member.joined_at.strftime('%b %d %Y %I:%M:%S %p') 
-        guild_info += f'\n» **Message count (last 30 days):** {await MessageRepository().get_user_message_count_range(member.id, member.guild.id, 30)}'
-        guild_info += f'\n» **Roles:** '
-        log.info(f'User has roles: {member.roles}')
-        #skipping the first index because it is just @everyone
-        for i in member.roles[1::]:
-            guild_info += f'{i.mention}'
-        guild_info += f'\n» **Highest role:** {member.top_role.mention}'
-        guild_info += f'\n» **Nitro boost date:** {member.premium_since}'
-        embed.add_field(name='**Guild Information:**', value=guild_info, inline=False)
+        if ctx.guild.get_member(user.id): 
+            guild_info = ''
+            if await self.bot.claims_check(ctx=ctx) is True:
+                #prints the datetime in the format of <Months> <day> <year> <hours>:<minutes>:<seconds> <AM/PM>
+                guild_info = '» **Joined:** ' + user.joined_at.strftime('%b %d %Y %I:%M:%S %p') 
+            guild_info += f'\n» **Message count (last 30 days):** {await MessageRepository().get_user_message_count_range(user.id, user.guild.id, 30)}'
+            guild_info += f'\n» **Roles:** '
+            log.info(f'User has roles: {user.roles}')
+            #skipping the first index because it is just @everyone
+            for i in user.roles[1::]:
+                guild_info += f'{i.mention}'
+            guild_info += f'\n» **Highest role:** {user.top_role.mention}'
+            guild_info += '\n» **Nitro boost date:** '+ (user.premium_since.strftime('%b %d %Y %I:%M:%S %p') if user.premium_since is not None else 'Not boosting')  
+            embed.add_field(name='**Guild Information:**', value=guild_info, inline=False)
         
         embed.set_footer(text=f'{ctx.author.name}#{ctx.author.discriminator}', icon_url=ctx.author.avatar_url)
         msg = await ctx.send(embed=embed)

--- a/bot/cogs/info_cog.py
+++ b/bot/cogs/info_cog.py
@@ -41,7 +41,7 @@ class InfoCog(commands.Cog):
         embed.set_thumbnail(url=user.avatar_url)
             
         #We don't want moderation info available for regular guild users to check on others
-        if await self.bot.claims_check(ctx=ctx) is True:
+        if (await self.bot.claims_check(ctx=ctx)) or (ctx.author.id == user.id):
             moderation_info = f'» **Warnings:** {len(await ModerationRepository().get_all_warns_member(ctx.guild.id, user.id))}'
             moderation_info += f'\n» **Active Mutes:** {len(await ModerationRepository().get_all_active_mutes_member(ctx.guild.id, user.id))}'
             moderation_info += f'\n» **Total Infractions:** {len(await ModerationRepository().get_all_infractions_member(ctx.guild.id, user.id))}'
@@ -63,7 +63,7 @@ class InfoCog(commands.Cog):
             for i in member.roles[1::]:
                 guild_info += f'{i.mention}'
             guild_info += f'\n» **Highest role:** {member.top_role.mention}'
-            guild_info += '\n» **Nitro boost date:** '+ member.premium_since.strftime('%b %d %Y %I:%M:%S %p') if member.premium_since is not None else 'Not boosting'  
+            guild_info += '\n» **Nitro boost date:** ' + (member.premium_since.strftime('%b %d %Y %I:%M:%S %p') if member.premium_since is not None else 'Not boosting')
             embed.add_field(name='**Guild Information:**', value=guild_info, inline=False)
         
         embed.set_footer(text=f'{ctx.author.name}#{ctx.author.discriminator}', icon_url=ctx.author.avatar_url)

--- a/bot/data/moderation_repository.py
+++ b/bot/data/moderation_repository.py
@@ -146,3 +146,12 @@ class ModerationRepository(BaseRepository):
                                     """,
                                   (guild_id, member_id)) as c:
                 return await self.fetcthall_as_class(c)
+    
+    async def get_global_bans(self, member_id):
+        async with aiosqlite.connect(self.resolved_db_path) as db:
+            async with db.execute(f"""
+                                    SELECT * FROM Infractions
+                                    WHERE fk_subjectId = ?
+                                    """,
+                                    (member_id,)) as c:
+                return await self.fetcthall_as_class(c)


### PR DESCRIPTION
- Fixed exceptions when calling on a user not in the current server
- Fixed the date string for nitro boosts (Should be fixed but cannot test without spending money to boost in the test server)
- Added a global ban counter to show how many guild's a user has been banned in that ClemBot is in
- The calling user can now see all their own statistics/information, but still not others without the proper claims